### PR TITLE
feat: don't focus on emoji-name input on mobile devices

### DIFF
--- a/public/lib/emoji-dialog.ts
+++ b/public/lib/emoji-dialog.ts
@@ -20,7 +20,9 @@ export const dialogActions = {
   open(dialog: JQuery): JQuery {
     $html.addClass('emoji-insert');
     dialog.addClass('open');
-    dialog.find('.emoji-dialog-search').focus();
+    if (!utils.isMobile()) {
+      dialog.find('.emoji-dialog-search').focus();
+    }
 
     return dialog;
   },

--- a/public/lib/types.d.ts
+++ b/public/lib/types.d.ts
@@ -18,6 +18,7 @@ declare const ajaxify: {
 };
 declare const utils: {
   generateUUID(): string;
+  isMobile(): boolean;
 };
 declare const Textcomplete: any;
 


### PR DESCRIPTION
Users reported a problem:
When you open the emoji dialog it automatically focuses on the input field for the emoji name.
Because of that browser shows the keyboard and it becomes really difficult to select one of the emojies (the keyboard overlays the emoji list).
This PR disables the focus on the input field for mobile devices.