### PR TITLE
fix: fix upstream change to textcomplete dependency

### DIFF
--- a/acp/rollup.config.js
+++ b/acp/rollup.config.js
@@ -11,7 +11,7 @@ const production = !process.env.ROLLUP_WATCH;
 
 export default {
   input: 'src/admin.ts',
-  external: ['translator', 'jquery', 'api', 'emoji'],
+  external: ['translator', 'jquery', 'api', 'emoji', '@textcomplete/core', '@textcomplete/textarea'],
   output: {
     sourcemap: !production,
     format: 'amd',

--- a/acp/src/Adjunct.svelte
+++ b/acp/src/Adjunct.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 import { createEventDispatcher, onMount } from 'svelte';
-import Textcomplete from 'textcomplete';
+import { Textcomplete } from '@textcomplete/core';
+import { TextareaEditor } from '@textcomplete/textarea';
 import { buildEmoji, strategy, table } from 'emoji';
 
 export let item: CustomAdjunct;
@@ -104,18 +105,16 @@ $: canSave = editing && !failures.any;
 
 let nameInput: HTMLInputElement;
 onMount(() => {
-  const editor = new Textcomplete.Textarea(nameInput);
-  const completer = new Textcomplete.Textcomplete(editor, {
+  const editor = new TextareaEditor(nameInput);
+  const completer = new Textcomplete(editor, [{
+    ...strategy,
+    replace: (data: StoredEmoji) => data.name,
+    match: /^(.+)$/,
+  }], {
     dropdown: {
       style: { zIndex: 20000 },
     },
   });
-
-  completer.register([{
-    ...strategy,
-    replace: (data: StoredEmoji) => data.name,
-    match: /^(.+)$/,
-  }]);
 
   completer.on('selected', () => {
     name = nameInput.value;

--- a/acp/src/modules.d.ts
+++ b/acp/src/modules.d.ts
@@ -14,13 +14,11 @@ module 'ajaxify' {
 }
 
 module '@textcomplete/core' {
-  const Textcomplete: any;
-  export default Textcomplete;
+  export const Textcomplete: any;
 }
 
 module '@textcomplete/textarea' {
-  const TextareaEditor: any;
-  export default TextareaEditor;
+  export const TextareaEditor: any;
 }
 
 module 'config' {

--- a/acp/src/modules.d.ts
+++ b/acp/src/modules.d.ts
@@ -13,9 +13,14 @@ module 'ajaxify' {
   export default ajaxify;
 }
 
-module 'textcomplete' {
+module '@textcomplete/core' {
   const Textcomplete: any;
   export default Textcomplete;
+}
+
+module '@textcomplete/textarea' {
+  const TextareaEditor: any;
+  export default TextareaEditor;
 }
 
 module 'config' {

--- a/public/lib/types.d.ts
+++ b/public/lib/types.d.ts
@@ -20,8 +20,6 @@ declare const ajaxify: {
 declare const utils: {
   generateUUID(): string;
 };
-declare const Textcomplete: any;
-declare const TextareaEditor: any;
 
 interface String {
   startsWith(str: string): boolean;

--- a/public/lib/types.d.ts
+++ b/public/lib/types.d.ts
@@ -21,6 +21,7 @@ declare const utils: {
   generateUUID(): string;
 };
 declare const Textcomplete: any;
+declare const TextareaEditor: any;
 
 interface String {
   startsWith(str: string): boolean;


### PR DESCRIPTION
### Caveat

I don't completely know what I am doing wrt svelte/ts, but I tried my best. Let me know if I did anything wrong here.

----

Upstream (core nodebb) updated from `textcomplete` to `@textcomplete/core`, which was a breaking change in terms of dependency. I don't consider this a breaking change for NodeBB because `textcomplete` is only used by composer-default. In fact, it should actually be required by composer/default, not core... but I will sort that out today if possible.

So really, emoji depends on textcomplete as a *peer dependency* which ideally shouldn't be the case. You'll recall the same thing happened when we updated async from v2 to v3, and some plugins broke because they were depending on async in core being v2.

So there are two solutions here.

1. `emoji` updates its code to instantiate textcomplete in the new way (**that is this PR**)
2. `emoji` changes its code to require `composer/autocomplete`, and calls the exported `.setup()` method, instead

Solution 2 is likely the more future proof step. This PR is mostly a band-aid.