### PR TITLE
fix: `type` parameter in `filter:parse.post` listener so that it expects it to be in `data` parameter instead of separate parameter

### DIFF
--- a/lib/parse.ts
+++ b/lib/parse.ts
@@ -223,8 +223,8 @@ export function raw(content: string): Promise<string> {
   return parse(content);
 }
 
-export async function post(data: { postData: { content: string } }, type: string): Promise<any> {
-  if (type === 'activitypub.note') {
+export async function post(data: { postData: { content: string }, type: string }): Promise<any> {
+  if (data.type === 'activitypub.note') {
     return data;
   }
 


### PR DESCRIPTION
Requirements stated:
> On `filter:parse.post`, check the `type` parameter now passed-in in NodeBB v4.

Which was incorrect on my part, should read:

> On `filter:parse.post`, check the `type` property now added (in NodeBB v4) to the first parameter.