### PR TITLE
fix: update @context property append

### DIFF
--- a/lib/parse.ts
+++ b/lib/parse.ts
@@ -313,7 +313,7 @@ async function importMime(): Promise<typeof import('mime').default> {
 export async function activitypubNote(data: {
   object: {
     source: { content: string },
-    '@context'?: { 'Emoji'?: string },
+    '@context'?: unknown,
     tag: {
       id: string;
       type: 'Emoji';
@@ -330,8 +330,16 @@ export async function activitypubNote(data: {
   const mime = await importMime();
 
   /* eslint-disable no-param-reassign */
-  data.object['@context'] = data.object['@context'] || {};
-  data.object['@context'].Emoji = 'http://joinmastodon.org/ns#Emoji';
+  data.object['@context'] = data.object['@context'] || [];
+  if (typeof data.object['@context'] === 'string') {
+    data.object['@context'] = [data.object['@context']];
+  }
+  if (Array.isArray(data.object['@context'])) {
+    data.object['@context'].push({
+      toot: 'http://joinmastodon.org/ns#',
+      Emoji: 'toot:Emoji',
+    });
+  }
 
   data.object.tag = data.object.tag || [];
 


### PR DESCRIPTION
The `@context` property can be a number of types, either a string, or an array containing either strings, or objects.

I don't know how to accurately specify the type without causing warnings in the type-checking logic below, but this is likely due to inexperience, hence why `unknown` is used.

Original requirement read:

> Add the following to `object.@context`: `{ "Emoji": "http://joinmastodon.org/ns#Emoji" }`

Should read

> Append the following to `object.@context`: `{ toot: "http://joinmastodon.org/ns#", "Emoji": "toot:Emoji" }`